### PR TITLE
Update mz_petalinux and pz_petalinux platforms to Vivado 2017.2.

### DIFF
--- a/Scripts/make.tcl
+++ b/Scripts/make.tcl
@@ -310,6 +310,7 @@ switch -nocase $board {
    PZSDR7035_FMCCC            -
    UZ3EG_IOCC                 -
    UZ3EG_PCIEC                -
+   UZ7EV_EVCC                 -
    ZC702                      -
    ZC706                      -
    ZCU102                     -

--- a/Scripts/make_mz_petalinux.tcl
+++ b/Scripts/make_mz_petalinux.tcl
@@ -44,6 +44,7 @@
 #  Revision:            Mar 26, 2016: 1.00 Initial version
 #                       Jun 16, 2016: 1.1  Updated to support 2015.4 tools
 #                       Jul 01, 2016: 1.2  Updated to support 2016.2 tools
+#                       Oct 10, 2017: 1.3  Updated to support 2017.2 tools
 # 
 # ----------------------------------------------------------------------------
 

--- a/Scripts/make_pz_petalinux.tcl
+++ b/Scripts/make_pz_petalinux.tcl
@@ -44,23 +44,24 @@
 #  Revision:            Feb 08, 2016: 1.00 Initial version
 #                       May 10, 2016: 1.1  Updated to support 2015.4 tools
 #                       Jul 01, 2016: 1.2  Updated to support 2016.2 tools
+#                       Nov 03, 2017: 1.3  Updated to support 2017.2 tools
 # 
 # ----------------------------------------------------------------------------
 
-# Build PetaLinux BSP HW Platform
-# for PicoZed 7010 SOM
+## Build PetaLinux BSP HW Platform
+## for PicoZed 7010 SOM
 set argv [list board=PZ7010_FMC2 project=pz_petalinux sdk=yes version_override=yes]
 set argc [llength $argv]
 source ./make.tcl -notrace
 
-# Build PetaLinux BSP HW Platform
-# for PicoZed 7015 SOM
+## Build PetaLinux BSP HW Platform
+## for PicoZed 7015 SOM
 set argv [list board=PZ7015_FMC2 project=pz_petalinux sdk=yes version_override=yes]
 set argc [llength $argv]
 source ./make.tcl -notrace
 
-# Build PetaLinux BSP HW Platform
-# for PicoZed 7020 SOM
+## Build PetaLinux BSP HW Platform
+## for PicoZed 7020 SOM
 set argv [list board=PZ7020_FMC2 project=pz_petalinux sdk=yes version_override=yes]
 set argc [llength $argv]
 source ./make.tcl -notrace


### PR DESCRIPTION
Added UZ7EV_EVCC board to make.tcl.